### PR TITLE
fix: open external url

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron'
+import { shell, app, BrowserWindow, ipcMain } from 'electron'
 import * as path from 'path'
 import * as isDev from 'electron-is-dev'
 import { registerUpdaterEvents, getOSName, getFreePort } from './updater'
@@ -105,6 +105,11 @@ const loadDecentralandWeb = async (win: BrowserWindow) => {
 
 const startApp = async (): Promise<void> => {
   const win = await createWindow()
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url)
+    return { action: 'deny' }
+  })
 
   if (!isDev) {
     const result = await autoUpdater.checkForUpdatesAndNotify()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dcl/explorer-desktop-launcher",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": "decentraland",
   "description": "Decentraland Desktop Launcher",
   "homepage": ".",


### PR DESCRIPTION
## What does this PR change?

When open a URL from electron, it will always open it from the default webbrowser

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
