### PR TITLE
fix: second instance

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,6 +11,12 @@ const config = {
   desktopBranch: 'main'
 }
 
+const isAppAllowed = app.requestSingleInstanceLock()
+
+if (!isAppAllowed) {
+  exit(0)
+}
+
 process.argv.shift() // Skip process name
 while (process.argv.length != 0) {
   switch (process.argv[0]) {
@@ -180,6 +186,10 @@ const startApp = async (): Promise<void> => {
     event.preventDefault()
   })
 
+  app.on('second-instance', (event, commandLine, workingDirectory) => {
+    showWindowAndHideTray(win)
+  })
+
   win.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url)
     return { action: 'deny' }
@@ -229,4 +239,5 @@ app.whenReady().then(async () => {
     //this allows exiting the launcher through command+Q or alt+f4
     isExitAllowed = true;
   });
+
 })


### PR DESCRIPTION
## What does this PR change?

Removed the creation of a second instance when executing the launcher twice, if the older instance is hidden on the tray it will be shown automatically.

Actually `macOS` prevents this but it's happening on other platforms.

Fixes https://github.com/decentraland/unity-renderer/issues/1636

## How to test the changes?

Launch the launcher and hide it into the tray.
Launch a second time and the first instance should show.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
