### PR TITLE
fix: window will close if renderer is not running

### DIFF
--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -49,8 +49,7 @@ const registerVersionEvent = (rendererPath: string, versionPath: string, baseUrl
 
     if (validVersion) {
       event.sender.executeJavaScript(
-        `globalThis.ROLLOUTS['@dcl/unity-renderer']['version'] = \"desktop-${
-          globalConfig.desktopBranch
+        `globalThis.ROLLOUTS['@dcl/unity-renderer']['version'] = \"desktop-${globalConfig.desktopBranch
         }.commit-${globalConfig.remoteVersion.substr(0, 7)}\";`
       )
     }
@@ -71,7 +70,8 @@ const registerExecuteProcessEvent = (rendererPath: string, executablePath: strin
           return
         }
 
-        console.log(data.toString())
+        console.log("Process terminated - " + data.toString())
+        ipcMain.emit("process-terminated");
       }
 
       let path = rendererPath + getBranchName() + executablePath
@@ -82,7 +82,7 @@ const registerExecuteProcessEvent = (rendererPath: string, executablePath: strin
 
       if (getOSName() === 'mac') {
         const { exec } = require('child_process')
-        exec('open "' + path + '" --args' + extraParams, onExecute)
+        exec('open -W "' + path + '" --args' + extraParams, onExecute)
       } else {
         const { exec } = require('child_process')
         exec(path + extraParams, onExecute)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dcl/explorer-desktop-launcher",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "author": "decentraland",
   "description": "Decentraland Desktop Launcher",
   "homepage": ".",


### PR DESCRIPTION
## What does this PR change?

The launcher will close if `renderer` is not running.
Also fixed macOS process ending right after `renderer` was executed, this allows for a proper event for opening the windows and hiding the tray

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
