### PR TITLE
fix: change app data path to be able to delete it on uninstall

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -47,7 +47,7 @@ if (getOSName() === null) {
 
 let isRendererOpen = false
 let isExitAllowed = false
-let rendererPath = `${app.getPath('appData')}/decentraland/renderer/`
+let rendererPath = `${app.getPath('appData')}/explorer-desktop-launcher/renderer/`
 let executablePath = `/unity-renderer-${osName}`
 let versionPath = `/version.json`
 const baseUrl = `https://renderer-artifacts.decentraland.org/desktop/`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@dcl/explorer-desktop-launcher",
-  "version": "0.1.15",
+  "name": "explorer-desktop-launcher",
+  "version": "0.1.16",
   "author": "decentraland",
   "description": "Decentraland Desktop Launcher",
   "homepage": ".",


### PR DESCRIPTION
## What does this PR change?

On uninstall, the AppData was not being deleted correctly with package name `@dcl/explorer-desktop-launcher`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
