### PR TITLE
fix: temporarily, use .zone instead of .org to be able to connect wit…

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -105,7 +105,7 @@ const loadDecentralandWeb = async (win: BrowserWindow) => {
     showLoading(win);
 
     const port = await getFreePort()
-    const stage = config.developerMode ? 'zone' : 'org'
+    const stage = 'zone' //config.developerMode ? 'zone' : 'org' // Temporal until we figure out how to use ws=ws://localhost:5000/dcl with .org and the new security measures
     let url = `http://play.decentraland.${stage}/?`
 
     if (config.customUrl) {


### PR DESCRIPTION
…h the WebSocket with the new security measures

## What does this PR change?

Temporal fix for: decentraland/unity-renderer#1717

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
