### PR TITLE
fix: execute the renderer even when the path has spaces

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -99,15 +99,18 @@ const startApp = async (): Promise<void> => {
     onOpenUrl(url, win)
   });
 
-  ipcMain.on('process-terminated', async (event) => {
+  ipcMain.on('process-terminated', async (event, reloadWebsite: boolean) => {
     main.isRendererOpen = false
 
-    // (#1457) we should reload the url
-    loadDecentralandWeb(win)
+    if (reloadWebsite) {
+      // (#1457) we should reload the url
+      loadDecentralandWeb(win)
+    }
+  
     showWindowAndHideTray(win)
   })
 
-  ipcMain.on('executeProcess', (event) => {
+  ipcMain.on('on-open-renderer', (event) => {
     main.isRendererOpen = true
     hideWindowInTray(win)
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-desktop-launcher",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "author": "decentraland",
   "description": "Decentraland Desktop Launcher",
   "homepage": ".",


### PR DESCRIPTION
fix: error on executing the renderer was triggering a reload without showing the error
fix: on error on executing we're not going to hide the renderer
feat: added ELECTRON_MODE and ROLLOUTS['@dcl/explorer-desktop'] to the global variables to use from other systems

## What does this PR change?

Fix https://github.com/decentraland/explorer-desktop/issues/82
Fix https://github.com/decentraland/unity-renderer/issues/1889

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
