### PR TITLE
fix: expose ipcRenderer from the preload and disable node integration

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,18 @@
+import { IpcRendererEvent, contextBridge, ipcRenderer } from "electron";
+
+// Expose protected methods that allow the renderer process to use
+// the ipcRenderer without exposing the entire object
+contextBridge.exposeInMainWorld(
+  "electron",
+  {
+    ipcRenderer: {
+      send(channel: string, ...args: any[]) {
+        ipcRenderer.send(channel, ...args)
+      },
+      on(channel: string, listener: (event: IpcRendererEvent, ...args: any[]) => void) {
+        ipcRenderer.on(channel, listener)
+        return this
+      }
+    }
+  }
+);

--- a/electron/window.ts
+++ b/electron/window.ts
@@ -14,11 +14,13 @@ export const createWindow = async (title: string, launcherPaths: LauncherPaths):
     minWidth: 1006,
     minHeight: 849,
     webPreferences: {
-      backgroundThrottling: false,
-      nodeIntegration: true,
-      // enableRemoteModule: true, // Deprecated in Electron 14 - https://stackoverflow.com/questions/69059668/enableremotemodule-is-missing-from-electron-v14-typescript-type-definitions
-      contextIsolation: false,
-      webSecurity: !isDev
+      nodeIntegration: false,
+      nodeIntegrationInWorker: false,
+      nodeIntegrationInSubFrames: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
+      webSecurity: true,
+      backgroundThrottling: false
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-desktop-launcher",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "author": "decentraland",
   "description": "Decentraland Desktop Launcher",
   "homepage": ".",

--- a/public/index.html
+++ b/public/index.html
@@ -200,7 +200,7 @@
     }
 
 
-    const { ipcRenderer } = window.require('electron')
+    const ipcRenderer = window.electron.ipcRenderer
 
     ipcRenderer.on('checkDeveloperMode', (event, { isDev, desktopBranch, customParams, previewMode }) => {
       if (isDev) {


### PR DESCRIPTION
## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
