### PR TITLE
fix: add entitlements info.plist with NSMicrophoneUsageDescription key

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -254,7 +254,7 @@ function initializeCrashReport() {
   crashReporter.start({ uploadToServer: false })
 }
 
-const askForMediaAccess = async (mediaType: string) => {
+const askForMediaAccess = async (mediaType: 'microphone' | 'camera') => {
   if (systemPreferences.askForMediaAccess) {
     // Electron currently only implements this on macOS
     return await systemPreferences.askForMediaAccess(mediaType);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { shell, app, BrowserWindow, ipcMain, Tray, Menu, crashReporter } from 'electron'
+import { shell, app, BrowserWindow, ipcMain, Tray, Menu, crashReporter, systemPreferences } from 'electron'
 import * as isDev from 'electron-is-dev'
 import { getOSName, getFreePort } from './updater'
 import { exit } from 'process'
@@ -202,6 +202,10 @@ const startApp = async (): Promise<void> => {
     await checkUpdates(win)
   }
 
+  const microphoneResult = await askForMediaAccess('microphone');
+  if (!microphoneResult) {
+    console.log('Microphone permission was not given')
+  }
   return Promise.resolve()
 }
 
@@ -248,4 +252,13 @@ function initializeCrashReport() {
   app.setPath('crashDumps', path)
 
   crashReporter.start({ uploadToServer: false })
+}
+
+const askForMediaAccess = async (mediaType: string) => {
+  if (systemPreferences.askForMediaAccess) {
+    // Electron currently only implements this on macOS
+    return await systemPreferences.askForMediaAccess(mediaType);
+  }
+  // For other platforms we can't reasonably do anything other than assume we have access.
+  return true;
 }

--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+        <true/>
+        <key>com.apple.security.device.microphone</key>
+        <true/>
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
+    </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       "hardenedRuntime": false,
       "entitlements": "entitlements.mac.plist",
       "extendInfo": {
-        "NSMicrophoneUsageDescription": "Need microphone access to use voice chat in the application",
+        "NSMicrophoneUsageDescription": "Need microphone access to use voice chat in the application"
       }
     },
     "dmg": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-desktop-launcher",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "author": "decentraland",
   "description": "Decentraland Desktop Launcher",
   "homepage": ".",

--- a/package.json
+++ b/package.json
@@ -113,9 +113,10 @@
         "dmg",
         "zip"
       ],
+      "hardenedRuntime": true,
       "entitlements": "entitlements.mac.plist",
       "extendInfo": {
-        "NSMicrophoneUsageDescription": "Need microphone access to use voice chat in the application"
+        "NSMicrophoneUsageDescription": "Need microphone access to use voice chat in the application",
       }
     },
     "dmg": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "dmg",
         "zip"
       ],
-      "hardenedRuntime": true,
+      "hardenedRuntime": false,
       "entitlements": "entitlements.mac.plist",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Need microphone access to use voice chat in the application",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,11 @@
       "target": [
         "dmg",
         "zip"
-      ]
+      ],
+      "entitlements": "entitlements.mac.plist",
+      "extendInfo": {
+        "NSMicrophoneUsageDescription": "Need microphone access to use voice chat in the application"
+      }
     },
     "dmg": {
       "icon": "public/installer-icon.icns",


### PR DESCRIPTION
What does this PR change?
On MacOS desktop version we have issue with voice chat not registering any input.
That is due not properly setting permission for the os.

How to test the changes?
Check if Decentraland app appears in System Preferences/Security & Privacy/Privacy/Microphone
Or the app requests for the permission during start.

Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md