### PR TITLE
fix: unsuported linux, closes #99

### DIFF
--- a/electron/helpers.ts
+++ b/electron/helpers.ts
@@ -61,7 +61,7 @@ export const getAppBasePath = (): string => {
   //dev
   if (process.env.RUN_ENV === 'development') return './'
 
-  if (!process.platform || !['win32', 'darwin'].includes(process.platform)) {
+  if (!process.platform || !['win32', 'darwin', 'linux'].includes(process.platform)) {
     console.error(`Unsupported OS: ${process.platform}`)
     return './'
   }
@@ -70,6 +70,8 @@ export const getAppBasePath = (): string => {
     return `/Users/${process.env.USER}/Library/Application\ Support/${applicationFolderName}/`
   } else if (process.platform === 'win32') {
     return `${process.env.LOCALAPPDATA}\\${applicationFolderName}\\`
+  } else if (process.platform === 'linux') {
+    return app.getPath('userData')
   }
 
   return './';

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -178,9 +178,9 @@ const registerExecuteProcessEvent = (rendererPath: string, executablePath: strin
       // We didn't find a way to get this windows store app package path dynamically
       if (process.windowsStore) {
         rendererPath = process.env.LOCALAPPDATA +
-            `\\Packages\\DecentralandFoundation.Decentraland_4zmdhd0rz3xz8\\LocalCache\\Roaming\\explorer-desktop-launcher\\renderer\\`
+          `\\Packages\\DecentralandFoundation.Decentraland_4zmdhd0rz3xz8\\LocalCache\\Roaming\\explorer-desktop-launcher\\renderer\\`
       }
-      
+
       let path = rendererPath + getBranchName() + executablePath
 
       let params = [`--browser`, `false`, `--port`, `${main.config.port}`]
@@ -249,6 +249,12 @@ const registerDownloadEvent = (win: BrowserWindow, launcherPaths: LauncherPaths)
 
           if (getOSName() === 'mac') {
             const execPath = `${branchPath}/unity-renderer-mac.app/Contents/MacOS/Decentraland`
+            console.log('execPath ' + execPath)
+            if (fs.existsSync(execPath)) {
+              fs.chmodSync(execPath, 0o755)
+            }
+          } else if (getOSName() === 'linux') {
+            const execPath = `${branchPath}/unity-renderer-linux`
             console.log('execPath ' + execPath)
             if (fs.existsSync(execPath)) {
               fs.chmodSync(execPath, 0o755)


### PR DESCRIPTION
## What does this PR change?
Fixes #99 

## How to test the changes?
On Linux platform, run `npm run start`, the explorer should start normally

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
