### PR TITLE
fix: open re-open launcher on windows

### DIFF
--- a/electron/window.ts
+++ b/electron/window.ts
@@ -78,6 +78,11 @@ export const hideWindowInTray = (win: BrowserWindow) => {
 
       main.contextMenu = Menu.buildFromTemplate([
         {
+          label: 'Open',
+          type: 'normal',
+          click: () => win.show()
+        },
+        {
           label: 'Exit',
           accelerator: 'CmdOrCtrl+Q',
           type: 'normal',
@@ -87,7 +92,8 @@ export const hideWindowInTray = (win: BrowserWindow) => {
 
       main.tray.setToolTip('Decentraland Launcher')
       main.tray.setContextMenu(main.contextMenu)
-      main.tray.on('right-click', (event) => main.tray?.popUpContextMenu(main.contextMenu))
+      main.tray.on('click', () => win.show())
+      main.tray.on('right-click', () => main.tray?.popUpContextMenu(main.contextMenu))
     } catch (e) {
       throw e
     }


### PR DESCRIPTION
## What does this PR change?

This PR fixes decentraland/explorer-desktop/issues/315

### Re-open the launcher by clicking on the launcher icon

https://user-images.githubusercontent.com/208789/210808504-130181a0-7257-4646-a0d4-167d89978b2e.mp4

### Re-open the launcher using right-click menu

https://user-images.githubusercontent.com/208789/210808801-920e073c-7b98-4047-864f-6f50b64b74f9.mp4

## How to test the changes? (windows only)

- build launcher
- install the new version
- open it
- minimize the launcher windows