### PR TITLE
fix: add `explorer-branch` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Runs the Electron app in the development mode.
 The Electron app will reload if you make edits in the `electron` directory.<br>
 You will also see any lint errors in the console.
 
+#### Custom arguments
+
+Use `-- <args>` to specify custom arguments
+- `--developer-mode` open the application in Developer Mode (with DevTools)
+- `--custom-url <url>` overrides the url, in Developer Mode it can be changed later
+- `--desktop-branch <branch_name> ` downloads the renderer of the specified branch and uses the corresponding browser-interface
+- `--desktop-version <version>` downloads the renderer of the specified version and uses the corresponding browser-interface
+
+e.g. `npm run start -- --developer-mode --desktop-branch main`
+
 ### `npm run build`
 
 Builds the Electron app package for production to the `dist` folder.

--- a/electron/cmdParser.ts
+++ b/electron/cmdParser.ts
@@ -9,15 +9,15 @@ export const parseConfig = (argv: string[]) => {
         break
       case '--custom-url':
         argv.shift()
-        main.config.customUrl = process.argv[0]
+        main.config.customUrl = argv[0]
         break
       case '--desktop-branch':
         argv.shift()
-        main.config.desktopBranch = process.argv[0]
+        main.config.desktopBranch = argv[0]
         break
       case '--desktop-version':
         argv.shift()
-        main.config.customDesktopVersion = process.argv[0]
+        main.config.customDesktopVersion = argv[0]
         break
     }
     argv.shift()

--- a/electron/window.ts
+++ b/electron/window.ts
@@ -132,6 +132,9 @@ export const loadDecentralandWeb = async (win: BrowserWindow) => {
 
     const stage = main.config.developerMode ? 'zone' : 'org'
     const url = new URL(main.config.customUrl || `http://play.decentraland.${stage}/?`)
+    
+    if (main.config.desktopBranch)
+      url.searchParams.append('explorer-branch', main.config.desktopBranch)    
 
     const customParamObj = new URLSearchParams(main.config.customParams)
     for (const [key, value] of Array.from(customParamObj.entries())) {

--- a/electron/window.ts
+++ b/electron/window.ts
@@ -134,8 +134,11 @@ export const loadDecentralandWeb = async (win: BrowserWindow) => {
     const url = new URL(main.config.customUrl || `http://play.decentraland.${stage}/?`)
     
     if (main.config.desktopBranch)
-      url.searchParams.append('explorer-branch', main.config.desktopBranch)    
-
+      url.searchParams.append('explorer-branch', main.config.desktopBranch)
+    
+    if (main.config.customDesktopVersion)
+      url.searchParams.append('explorer-version', main.config.customDesktopVersion)
+    
     const customParamObj = new URLSearchParams(main.config.customParams)
     for (const [key, value] of Array.from(customParamObj.entries())) {
       url.searchParams.append(key, value)


### PR DESCRIPTION
When the build had been launched from the `desktop-launcher` it had never respected the kernel version:

- it was always downloading the proper renderer version
- but used `main` version of the kernel
- it produced inconsistency of testing in various scenarios
- we were pretty lucky not to notice severe consequences of such behavior

I fixed it by adding `explorer-branch` / `explorer-version` argument if the corresponding arguments are passed to the launcher