### PR TITLE
fix: race condition on choosing which browser interface version is going to use on explorer-website (remove injection of @dcl/explorer from the launcher)

### DIFF
--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -82,14 +82,6 @@ const registerVersionEvent = (launcherPaths: LauncherPaths) => {
       // download please
       event.sender.send('downloadState', { type: 'NEW_VERSION' })
     }
-
-    if (validVersion && !PREVIEW) {
-      const desktopVersion = main.config.desktopBranch
-        ? JSON.stringify(`dev-desktop-${main.config.desktopBranch}.commit-${remoteVersion.substring(0, 7)}`)
-        : JSON.stringify(`desktop-${remoteVersion}`)
-
-      await event.sender.executeJavaScript(`globalThis.ROLLOUTS['@dcl/explorer'] = { 'version': ${desktopVersion} };`)
-    }
   })
 }
 


### PR DESCRIPTION
## What does this PR change?

The launcher was injecting the @dcl/explorer version just to fix the /version command, but since we merged kernel+renderer, it's no longer needed, and we were injecting that code incorrectly. Generating a race condition that if the code was injected before the explorer-website loads the rollouts, it will take a no-sense version

Fix https://github.com/decentraland/unity-renderer/issues/5067

## Test

1. Open Launcher
2. Test if opens the last version of @dcl/explorer correctly (can be checked with /version)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
